### PR TITLE
chore: bump 3d-store-trigger image to v2.0.1 (MAPCO-9268)

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -54,7 +54,7 @@ mcLabelsAndAnnotations:
 
 image:
   repository: store-trigger
-  tag: 'latest'
+  tag: v2.0.1
 
 nodePort: 30030
 replicaCount: 1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -54,7 +54,7 @@ mcLabelsAndAnnotations:
 
 image:
   repository: store-trigger
-  tag: v2.0.1
+  tag:
 
 nodePort: 30030
 replicaCount: 1


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change |✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |
